### PR TITLE
feat: Websocket authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,23 @@ This issued token uses `anonymous-<uuid>` for the `sub` property.
 
 If both a token and an anonymous id are provided, the anonymous id is ignored.
 
+## Using it for websockets
+
+To authenticate websockets requests, call `verifyTokenInWebsocketUpgradeRequest`.
+
+```javascript
+server.on('upgrade', async (request, socket, head) => {
+  const result = await limes.verifyTokenInWebsocketUpgradeRequest({
+    issuerForAnonymousTokens: 'https://anonymous.thenativeweb.io',
+    upgradeRequest: request
+  })
+  
+  ws.handleUpgrade(request, socket, head, () => {
+    // ...
+  });
+})
+```
+
 ## Running the build
 
 ```shell

--- a/lib/Limes.ts
+++ b/lib/Limes.ts
@@ -1,7 +1,7 @@
 import { Claims } from './Claims';
 import { IdentityProvider } from './IdentityProvider';
-import { Request, RequestHandler } from 'express';
 import jwt, { VerifyErrors } from 'jsonwebtoken';
+import { Request, RequestHandler } from 'express';
 
 declare global {
   /* eslint-disable @typescript-eslint/no-namespace */

--- a/lib/Limes.ts
+++ b/lib/Limes.ts
@@ -240,7 +240,7 @@ class Limes {
       try {
         decodedToken = await this.verifyToken({ token });
       } catch {
-        throw new Error('Token not decodable.');
+        throw new Error('Failed to decode token.');
       }
     } else {
       const payload = {

--- a/test/unit/LimesTests.ts
+++ b/test/unit/LimesTests.ts
@@ -1,10 +1,10 @@
 import { assert } from 'assertthat';
-import express, { Express, Request } from 'express';
 import fs from 'fs';
 import jwt from 'jsonwebtoken';
 import path from 'path';
 import request from 'supertest';
 import { uuid } from 'uuidv4';
+import express, { Express, Request } from 'express';
 import { IdentityProvider, Limes } from '../../lib/Limes';
 
 /* eslint-disable no-sync */

--- a/test/unit/LimesTests.ts
+++ b/test/unit/LimesTests.ts
@@ -387,10 +387,12 @@ suite('Limes', (): void => {
         }
       } as unknown as Request;
 
-      await assert.that(async (): Promise<any> => await limes.verifyTokenInWebsocketUpgradeRequest({
-        issuerForAnonymousTokens: 'https://untrusted.thenativeweb.io',
-        upgradeRequest
-      })).is.throwingAsync();
+      await assert.that(async (): Promise<void> => {
+        await limes.verifyTokenInWebsocketUpgradeRequest({
+          issuerForAnonymousTokens: 'https://untrusted.thenativeweb.io',
+          upgradeRequest
+        });
+      }).is.throwingAsync();
     });
 
     test('throws an error for tokens with invalid characters.', async (): Promise<void> => {
@@ -400,10 +402,12 @@ suite('Limes', (): void => {
         }
       } as unknown as Request;
 
-      await assert.that(async (): Promise<any> => await limes.verifyTokenInWebsocketUpgradeRequest({
-        issuerForAnonymousTokens: 'https://untrusted.thenativeweb.io',
-        upgradeRequest
-      })).is.throwingAsync();
+      await assert.that(async (): Promise<void> => {
+        await limes.verifyTokenInWebsocketUpgradeRequest({
+          issuerForAnonymousTokens: 'https://untrusted.thenativeweb.io',
+          upgradeRequest
+        });
+      }).is.throwingAsync();
     });
 
     test('throws an error for expired tokens.', async (): Promise<void> => {
@@ -422,10 +426,12 @@ suite('Limes', (): void => {
         }
       } as unknown as Request;
 
-      await assert.that(async (): Promise<any> => await limes.verifyTokenInWebsocketUpgradeRequest({
-        issuerForAnonymousTokens: 'https://untrusted.thenativeweb.io',
-        upgradeRequest
-      })).is.throwingAsync();
+      await assert.that(async (): Promise<void> => {
+        await limes.verifyTokenInWebsocketUpgradeRequest({
+          issuerForAnonymousTokens: 'https://untrusted.thenativeweb.io',
+          upgradeRequest
+        });
+      }).is.throwingAsync();
     });
 
     test('throws an error for tokens that were issued by an unknown identity provider.', async (): Promise<void> => {
@@ -444,10 +450,12 @@ suite('Limes', (): void => {
         }
       } as unknown as Request;
 
-      await assert.that(async (): Promise<any> => await limes.verifyTokenInWebsocketUpgradeRequest({
-        issuerForAnonymousTokens: 'https://untrusted.thenativeweb.io',
-        upgradeRequest
-      })).is.throwingAsync();
+      await assert.that(async (): Promise<void> => {
+        await limes.verifyTokenInWebsocketUpgradeRequest({
+          issuerForAnonymousTokens: 'https://untrusted.thenativeweb.io',
+          upgradeRequest
+        });
+      }).is.throwingAsync();
     });
 
     test('returns a decoded token for valid tokens.', async (): Promise<void> => {


### PR DESCRIPTION
This provides an additional method intended for use with websockets.

It does much of the same thing the middleware does, but it only considers the http headers of the update request, and not the query body.