### PR TITLE
feat: add algorithm property to identity provider

### DIFF
--- a/lib/IdentityProvider.ts
+++ b/lib/IdentityProvider.ts
@@ -1,5 +1,7 @@
 const minutesPerDay = 24 * 60;
 
+type TAlgorithm = "RS256" | "RS384" | "RS512" | "ES256" | "ES384" | "ES512";
+
 class IdentityProvider {
   public issuer: string;
 
@@ -7,22 +9,27 @@ class IdentityProvider {
 
   public certificate?: Buffer;
 
+  public algorithm: TAlgorithm;
+
   public expiresInMinutes: number;
 
   public constructor ({
     issuer,
     privateKey,
     certificate,
+    algorithm = 'RS256',
     expiresInMinutes = minutesPerDay
   }: {
     issuer: string;
     privateKey?: Buffer;
     certificate?: Buffer;
+    algorithm?: TAlgorithm;
     expiresInMinutes?: number;
   }) {
     this.issuer = issuer;
     this.privateKey = privateKey;
     this.certificate = certificate;
+    this.algorithm = algorithm;
     this.expiresInMinutes = expiresInMinutes;
   }
 }

--- a/lib/Limes.ts
+++ b/lib/Limes.ts
@@ -1,8 +1,11 @@
-import { Claims } from './Claims';
 import { flaschenpost } from 'flaschenpost';
-import { IdentityProvider } from './IdentityProvider';
+
 import jwt from 'jsonwebtoken';
+
 import { RequestHandler } from 'express';
+
+import { Claims } from './Claims';
+import { IdentityProvider } from './IdentityProvider';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -86,7 +89,7 @@ class Limes {
     }
 
     const token = jwt.sign(payload, identityProvider.privateKey, {
-      algorithm: 'RS256',
+      algorithm: identityProvider.algorithm,
       subject,
       issuer: identityProvider.issuer,
       expiresIn: identityProvider.expiresInMinutes * 60
@@ -132,7 +135,7 @@ class Limes {
           token,
           identityProvider.certificate,
           {
-            algorithms: [ 'RS256' ],
+            algorithms: [ identityProvider.algorithm ],
             issuer: identityProvider.issuer
           },
           (err, verifiedToken): void => {


### PR DESCRIPTION
Add the configuration "RS256" | "RS384" | "RS512" | "ES256" | "ES384" | "ES512" to use limes for other keycloak configuration. 

Task: 

- [x] add more algorithm
- [x] make sure we are backward compatible 
- [ ] test for the new algorithm configuration 